### PR TITLE
change default port to 9443 + improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See [https://docs.docker.com/compose/install/#install-compose](https://docs.dock
 
 ### Step 2 - Change the address of the VIRTUAL_HOST
 
-Go to the `docker-compose.yml` file and change the `VIRTUAL_HOST` value (environment variable of the `matomo-app` container). Now it is set to `https://localhost:8443`, which works when testing locally, but change it to the appropriate host if you want to set up the application in a different place.
+Go to the `docker-compose.yml` file and change the `VIRTUAL_HOST` value (environment variable of the `matomo-app` container). Now it is set to `https://localhost:9443`, which works when testing locally, but change it to the appropriate host if you want to set up the application in a different place.
 
 ### Step 3 - Configure apache reverse HTTPS proxy
 
@@ -46,7 +46,7 @@ docker-compose up -d
 
 ### Step 5 - Open the Matomo app and follow the installation steps
 
-In your browser, go to the address specified in `VIRTUAL_HOST` (default: `https://localhost:8443/`), and you will see the Matomo Welcome Screen. Follow the installation steps that are shown in the screen:
+In your browser, go to the address specified in `VIRTUAL_HOST` (default: `https://localhost:9443/`), and you will see the Matomo Welcome Screen. Follow the installation steps that are shown in the screen:
 - For Step 1 and Step 2 you don't need to change anything, just press `Next`.
 - In `Step 3: Database Setup`, change the values of the following parameters:
 
@@ -67,7 +67,7 @@ In your browser, go to the address specified in `VIRTUAL_HOST` (default: `https:
   and hit `Next`.
 - In Step 6, you are going to set up a Website to track. You can add more websites to track later. Once you have filled the fields, click `Next`.
 - In Step 7, you will see the JavaScript Tracking Code for the website you configured in Step 6. This piece of code is used to track what the users are doing in your website and report it to Matomo. Therefore, you must copy the code and paste it inside the `<header>` section of every page of your website. This JavaScript Tracking code can be customized to specifically track what you want or deal with different types of websites, more information can be found [here](https://developer.matomo.org/guides/tracking-javascript-guide). For customizing cBioPortal, check the section [Integration of Matomo with cBioPortal](#integration-of-matomo-with-cbioportal) below. Once you finished installing the JavaScript Tracking Code on your website, click `Next`.
-- At the end of the wizard you will see a `Congratulations` page. Click `Continue to Matomo` to access the Matomo's log in page, where you should log in with your Super User credentials. This is the page you will see from now on every time you access Matomo via the address specified in `VIRTUAL_HOST` (default: `https://localhost:8443/`). If you see a warning message instead of the login page, you need to adjust the `config.init.php` file (explained in the following section: step 6).
+- At the end of the wizard you will see a `Congratulations` page. Click `Continue to Matomo` to access the Matomo's log in page, where you should log in with your Super User credentials. This is the page you will see from now on every time you access Matomo via the address specified in `VIRTUAL_HOST` (default: `https://localhost:9443/`). If you see a warning message instead of the login page, you need to adjust the `config.init.php` file (explained in the following section: step 6).
 
 Once logged in to the Matomo admin panel,
 head to the Administration icon in the top-right corner,
@@ -90,7 +90,7 @@ trusted_hosts[] = "localhost"
 
 by this:
 ```
-trusted_hosts[] = "localhost:8443"
+trusted_hosts[] = "localhost:9443"
 ```
 
 ### All set

--- a/apache-proxy/httpd.conf
+++ b/apache-proxy/httpd.conf
@@ -49,9 +49,7 @@ ServerRoot "/usr/local/apache2"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 80
-Listen 443
-Listen 8443
+Listen 9443
 
 #
 # Dynamic Shared Object (DSO) Support
@@ -522,7 +520,7 @@ LogLevel warn
 #Include conf/extra/httpd-vhosts.conf
 
 # Redirect https to port 80 of the Matomo container
-<VirtualHost *:8443>
+<VirtualHost *:9443>
   SSLEngine on
   SSLCertificateFile /etc/ssl/cbio_https/cert.crt
   SSLCertificateKeyFile /etc/ssl/cbio_https/key.key

--- a/apache-proxy/httpd.conf
+++ b/apache-proxy/httpd.conf
@@ -317,7 +317,7 @@ ErrorLog /proc/self/fd/2
 # Possible values include: debug, info, notice, warn, error, crit,
 # alert, emerg.
 #
-LogLevel warn
+LogLevel info
 
 <IfModule log_config_module>
     #
@@ -533,8 +533,6 @@ LogLevel warn
   RequestHeader set X-Forwarded-Proto https
 
   Header always set Strict-Transport-Security "max-age=15768000"
-
-  LogLevel info
 
   ProxyPass / http://matomo-app:80/
   ProxyPassReverse / http://matomo-app:80/

--- a/apache-proxy/httpd.conf
+++ b/apache-proxy/httpd.conf
@@ -534,9 +534,7 @@ LogLevel warn
 
   Header always set Strict-Transport-Security "max-age=15768000"
 
-  ErrorLog /tmp/matomo_https_error.log
-  LogLevel warn
-  CustomLog /tmp/matomo_https_access.log combined
+  LogLevel info
 
   ProxyPass / http://matomo-app:80/
   ProxyPassReverse / http://matomo-app:80/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "./config:/var/www/html/config:rw"
       - "./logs:/var/www/html/logs"
     environment:
-      - "VIRTUAL_HOST=https://localhost:8443"
+      - "VIRTUAL_HOST=https://localhost:9443"
 
   matomo-db:
     networks:
@@ -41,7 +41,7 @@ services:
     - ./apache-proxy/cert.crt:/etc/ssl/cbio_https/cert.crt
     - ./apache-proxy/key.key:/etc/ssl/cbio_https/key.key
     ports:
-    - "8443:8443"
+    - "9443:9443"
     depends_on:
     - matomo-app
     - matomo-db


### PR DESCRIPTION
This PR:
- changes default port to 9443 as 8443 is many times already taken
- improves apache logging (logs are made visible in docker logs)